### PR TITLE
fix an exception for int16 not casting correctly

### DIFF
--- a/Runtime/OSCQuery.cs
+++ b/Runtime/OSCQuery.cs
@@ -560,7 +560,7 @@ namespace OSCQuery
                 case "System.SByte":
                     {
                         //add range
-                        vo.Add((int)value);
+                        vo.Add(Convert.ToInt32(value));
                         poType = "i";
                     }
                     break;

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "repository": "github:benkper/Unity-OSCQuery",
   "unity": "2023.2",
   "unityRelease": "20f1",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
change a (int) cast to Convert.ToInt32
and also increment plugin version