### PR TITLE
Fix missing script error

### DIFF
--- a/Runtime/OSCQuery.cs
+++ b/Runtime/OSCQuery.cs
@@ -348,6 +348,12 @@ namespace OSCQuery
 
             foreach (Component comp in comps)
             {
+                if(comp == null)
+                {
+                    Debug.LogWarning("Null component found in " + go.name + ", skipping");
+                    continue;
+                }
+            
                 int dotIndex = comp.GetType().ToString().LastIndexOf(".");
                 string compType = comp.GetType().ToString().Substring(Mathf.Max(dotIndex + 1, 0));
 

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "repository": "github:benkper/Unity-OSCQuery",
   "unity": "2023.2",
   "unityRelease": "20f1",
-  "version": "1.2.3"
+  "version": "1.2.4"
 }


### PR DESCRIPTION
If a script is missing in a project. The comp associated to the missing script is null. 
I added a check to avoid adding to tree empty comp.

I also raised plugin version to 1.2.3